### PR TITLE
Return a richer set of run data

### DIFF
--- a/databroker_server/model/databroker.py
+++ b/databroker_server/model/databroker.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from databroker import catalog
 
 
@@ -37,7 +39,9 @@ def rich_runs(name: str):
         run_data["uid"] = uid
         run = current[uid]
         run_data["scan_id"] = run.metadata["start"]["scan_id"]
-        run_data["time"] = run.metadata["start"]["time"]
+        run_data["timestamp"] = run.metadata["start"]["time"]
+        run_data["date_time"] = datetime.fromtimestamp(run.metadata["start"]["time"])
+        run_data["plan_name"] = run.metadata["start"]["plan_name"]
         run_list.append(run_data)
 
     return run_list

--- a/databroker_server/model/databroker.py
+++ b/databroker_server/model/databroker.py
@@ -22,6 +22,27 @@ def runs(name: str):
     return list(current)
 
 
+def rich_runs(name: str):
+    """ Get a rich list of runs for a catalog."""
+    try:
+        current = catalog[name]
+    except KeyError:
+        return None
+    if not _has_runs(current):
+        return None
+
+    run_list = []
+    for uid in current:
+        run_data = {}
+        run_data["uid"] = uid
+        run = current[uid]
+        run_data["scan_id"] = run.metadata["start"]["scan_id"]
+        run_data["time"] = run.metadata["start"]["time"]
+        run_list.append(run_data)
+
+    return run_list
+
+
 def run_summary(catalog_id: str, uid: str):
     """Generate a summary of the selected run."""
     try:

--- a/databroker_server/routers/runs.py
+++ b/databroker_server/routers/runs.py
@@ -17,12 +17,11 @@ async def list_catalogs():
 async def read_catalog(catalog_name: str):
     """List the runs within the supplied catalog."""
     runs = []
-    run_list = databroker.runs(catalog_name)
+    run_list = databroker.rich_runs(catalog_name)
     if run_list is None:
         raise HTTPException(status_code=404, detail="Not found")
-    for run in run_list:
-        runs.append({"uid": run})
-    return runs
+
+    return run_list
 
 
 @router.get("/{catalog_name}/{run_uid}")


### PR DESCRIPTION
I added this a few weeks ago, and forgot to push it. It is backwards
compatible with the old returned data as it just adds more. This is
intended to support a richer result page when looking at runs in a
catalog, and eventually when searching runs in a catalog.